### PR TITLE
Don't swallow syntax errors

### DIFF
--- a/lib/coffee-react-cache.js
+++ b/lib/coffee-react-cache.js
@@ -49,19 +49,19 @@ function cacheFile(filename) {
 
   // If we don't have the content, we need to compile ourselves
   if (!content) {
+    // Read from disk and then compile
+    var compiled = coffee.compile(fs.readFileSync(filename, 'utf8'), {
+      filename: filename,
+      sourceMap: true
+    });
+    content = compiled.js;
+
+    // Since we don't know which version of CoffeeScript we have, make sure
+    // we handle the older versions that return just the compiled version.
+    if (content == null)
+      content = compiled;
+
     try {
-      // Read from disk and then compile
-      var compiled = coffee.compile(fs.readFileSync(filename, 'utf8'), {
-        filename: filename,
-        sourceMap: true
-      });
-      content = compiled.js;
-
-      // Since we don't know which version of CoffeeScript we have, make sure
-      // we handle the older versions that return just the compiled version.
-      if (content == null)
-        content = compiled;
-
       // Try writing to cache
       mkpath.sync(path.dirname(cachePath));
       fs.writeFileSync(cachePath, content, 'utf8');


### PR DESCRIPTION
Before this fix, if I tried to start a node server when a coffee/cjsx file has a syntax error, I got:

``` sh
express server starting
coffee-react-cache: Could not write cache at .coffee.

(null):0
(null)

RangeError: Maximum call stack size exceeded
```

With this fix I get:

``` sh
express server starting
foo/bar/controller.cjsx:42:3: error: unmatched )
  )
  ^
```

FYI @bobzoller 
